### PR TITLE
fix(faucet): Faucet should not transfer funds after throwing quota errors

### DIFF
--- a/pkg/faucet/cosmosfaucet.go
+++ b/pkg/faucet/cosmosfaucet.go
@@ -50,7 +50,7 @@ func (f Faucet) ValidateRequest(req TransferRequest) error {
 	for _, coin := range req.Coins {
 		if _, ok := f.MaxCoinsPerAccount[coin.Denom]; ok {
 			if coin.Amount.GT(f.MaxCoinsPerRequest[coin.Denom]) {
-				return fmt.Errorf("%s is greater than max allowed per request of %s%s", coin.String(), f.MaxCoinsPerRequest[coin.Denom].String(), coin.Amount.String())
+				return fmt.Errorf("%s is greater than max allowed per request of %s%s", coin.String(), coin.Denom, f.MaxCoinsPerRequest[coin.Denom].String())
 			}
 		} else {
 			return fmt.Errorf("Faucet not allowed to distribute %s", coin.Denom)

--- a/pkg/faucet/server.go
+++ b/pkg/faucet/server.go
@@ -64,6 +64,7 @@ func (f Faucet) faucetHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		responseError(w, http.StatusInternalServerError, err)
+		return
 	}
 
 	// try performing the transfer


### PR DESCRIPTION
Currently the faucet has malformated error response if the request to get funds fails due to quota limits and the faucet still transfers funds

Request
```
curl -X 'POST' \
  'https://faucet.titus-1.archway.tech/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "address": "archway1nxf6r6n0z98kpwg4f40rx95yfnghq4nufkxnep",
  "coins": [
    "100000000utitus"
  ]
}'
```
Response
```
can't parse JSON.  Raw result:

{"error":"100000000utitus is greater than max allowed per request of 10000000100000000"}{}
```